### PR TITLE
fix: make rank_score field optional in VideoSearchData model

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.1
+version: 0.0.2
 type: plugin
 author: jingfelix
 name: bilibili_search

--- a/tools/model.py
+++ b/tools/model.py
@@ -1,4 +1,5 @@
 from pydantic import BaseModel
+from typing import Optional
 
 
 class VideoSearchData(BaseModel):
@@ -12,7 +13,7 @@ class VideoSearchData(BaseModel):
     review: int
     pubdate: int
     duration: str
-    rank_score: int
+    rank_score: Optional[int] = None
     like: int
 
 


### PR DESCRIPTION
- Changed rank_score from required int to Optional[int] with default None
- Fixes Pydantic validation error when API response lacks rank_score field
- Added Optional import from typing module